### PR TITLE
Fix AIS ship name overwriting in Supabase uploads

### DIFF
--- a/app/src/main/java/com/example/segnmea/GlobalData.kt
+++ b/app/src/main/java/com/example/segnmea/GlobalData.kt
@@ -25,6 +25,11 @@ object GlobalData {
         }
         aisListeners.forEach { it(aisTargets) }
     }
+
+    @Synchronized
+    fun getAisTarget(mmsi: Int): AisTarget? {
+        return aisTargets[mmsi]?.copy()
+    }
     
     fun addAisListener(listener: (Map<Int, AisTarget>) -> Unit) {
         aisListeners.add(listener)

--- a/app/src/main/java/com/example/segnmea/SupabaseForegroundService.kt
+++ b/app/src/main/java/com/example/segnmea/SupabaseForegroundService.kt
@@ -94,8 +94,9 @@ class SupabaseForegroundService : Service() {
             val target = aisParser.parse(line)
             if (target != null) {
                 GlobalData.updateAis(target)
+                val fullTarget = GlobalData.getAisTarget(target.mmsi) ?: target
                 scope.launch {
-                    sendAisToSupabase(target)
+                    sendAisToSupabase(fullTarget)
                 }
             }
         } else {
@@ -166,7 +167,7 @@ class SupabaseForegroundService : Service() {
         if (target.course != null) json.put("cog", target.course)
         if (target.heading != null) json.put("heading", target.heading)
         if (target.rot != null) json.put("rot", target.rot)
-        if (target.name != null) json.put("ship_name", target.name)
+        if (!target.name.isNullOrEmpty()) json.put("ship_name", target.name)
         json.put("source_id", shipId)
         
         // For UPSERT to work on MMSI primary key, we need specific header


### PR DESCRIPTION
Implemented local caching of AIS targets in `GlobalData` to persist ship names across position reports. Modified `SupabaseForegroundService` to use the merged/cached target data when uploading to Supabase, ensuring that `ship_name` is included if available. Also added a check to exclude `ship_name` from the JSON payload if it is null or empty, preventing Supabase from overwriting existing names with NULL or empty strings.

---
*PR created automatically by Jules for task [11609093244384115040](https://jules.google.com/task/11609093244384115040) started by @nippur1975*